### PR TITLE
require @bugsnag/js 6+ since bugsnag-node is deprecatated

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "nyc": "^13.0.1"
   },
   "peerDependencies": {
-    "bugsnag": "2.x"
+    "@bugsnag/js": "6.x"
   }
 }


### PR DESCRIPTION
see archived, deprecatated [bugsnag-node repo](https://github.com/bugsnag/bugsnag-node)