### PR TITLE
Migrate to new bugsnag (@bugsnag/js v6.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - '10'
   - '8'
 before_install:
-  - npm install -g yarn
+  - npm install -g yarn@1.10.1
 install:
   - yarn install --pure-lockfile
 script:

--- a/README.md
+++ b/README.md
@@ -21,14 +21,13 @@ Setup your `bugsnag` like this:
 
 const bugsnag = require('bugsnag')
 
-bugsnag.register(process.env.BUGSNAG_API_KEY, {
-  releaseStage: process.env.SERVICE_ENV,
-  notifyReleaseStages: ['prod', 'stage']
+const bugsnagClient = bugsnag({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  notifyReleaseStages: ['prod', 'stage'],
+  releaseStage: process.env.SERVICE_ENV
 })
 
-require('paperplane-bugsnag')(bugsnag)
-
-module.exports = bugsnag
+module.exports = require('paperplane-bugsnag')(bugsnagClient)
 ```
 
 Then use it as the `cry` option in `paperplane` like this:

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "nyc": "^13.0.1"
   },
   "peerDependencies": {
-    "bugsnag": "2.x"
+    "@bugsnag/js": "6.x"
   }
 }


### PR DESCRIPTION
## Description
[bugsnag](https://www.npmjs.com/package/bugsnag) has been deprecated in favor of their new universal javascript notifier [@bugsnag/js](https://www.npmjs.com/package/@bugsnag/js). In the move, they changed the way their `beforeSend` hook works. This PR reimplements the paperplane adapter to wrap `bugsnag.notify()`, redacting request data before calling the real `bugsnag.notify()` rather than using the `beforeSend` hooks.