### PR TITLE
Set yarn version in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - '10'
   - '8'
 before_install:
-  - npm install -g yarn
+  - npm install -g yarn@1.10.1
 install:
   - yarn install --pure-lockfile
 script:


### PR DESCRIPTION
Copies the Travis yarn version from [paperplane](https://github.com/articulate/paperplane/blob/master/.travis.yml#L7) in an attempt to get Travis builds to pass.