### PR TITLE
Allow passing a custom logger to the setup function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { logger } = require('paperplane')
+const paperplane = require('paperplane')
 
 const {
   always, anyPass, complement, compose, evolve, gt,
@@ -28,7 +28,8 @@ const redacted =
 const redactHeaders =
   evolve({ authorization: redacted, cookie: redacted })
 
-const setup = bugsnagClient => {
+const setup = (bugsnagClient, logger = paperplane.logger) => {
+  console.log('hello')
   const notify = (err, opts) => {
     const { req } = err
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ const redactHeaders =
   evolve({ authorization: redacted, cookie: redacted })
 
 const setup = (bugsnagClient, logger = paperplane.logger) => {
-  console.log('hello')
   const notify = (err, opts) => {
     const { req } = err
 

--- a/test.js
+++ b/test.js
@@ -5,6 +5,49 @@ const spy = require('@articulate/spy')
 const mockLogger = require('paperplane').logger = spy()
 const setup = require('.')
 
+describe('logger', () => {
+  let bugsnag
+  const mockNotify = spy()
+
+  const mockBugsnagClient = {
+    notify: mockNotify,
+  }
+
+  afterEach(() => {
+    mockLogger.reset()
+    mockNotify.reset()
+  })
+
+  describe('without a custom logger', () => {
+    const err = Boom.notFound()
+
+    beforeEach(() => {
+      bugsnag = setup(mockBugsnagClient)
+      bugsnag.notify(err)
+    })
+
+    it('logs', () => {
+      expect(mockLogger.calls.length).to.equal(1)
+      expect(mockLogger.calls[0]).to.eql([ err ])
+    })
+  })
+
+  describe('with a custom logger', () => {
+    const err = Boom.notFound()
+    const customLogger = spy()
+
+    beforeEach(() => {
+      bugsnag = setup(mockBugsnagClient, customLogger)
+      bugsnag.notify(err)
+    })
+
+    it('logs', () => {
+      expect(customLogger.calls.length).to.equal(1)
+      expect(customLogger.calls[0]).to.eql([ err ])
+    })
+  })
+})
+
 describe('paperplane-bugsnag + bugsnag.notify', () => {
   let bugsnag
   const mockNotify = spy()

--- a/test.js
+++ b/test.js
@@ -26,7 +26,7 @@ describe('logger', () => {
       bugsnag.notify(err)
     })
 
-    it('logs', () => {
+    it('logs with the paperlane logger', () => {
       expect(mockLogger.calls.length).to.equal(1)
       expect(mockLogger.calls[0]).to.eql([ err ])
     })
@@ -41,7 +41,7 @@ describe('logger', () => {
       bugsnag.notify(err)
     })
 
-    it('logs', () => {
+    it('logs with the custom logger', () => {
       expect(customLogger.calls.length).to.equal(1)
       expect(customLogger.calls[0]).to.eql([ err ])
     })


### PR DESCRIPTION
![log](https://media.giphy.com/media/3orif7jbVVhqy0ba1O/giphy.gif)

Most applications define a custom logger.  Hard-coding the logger to use the paperplane logger makes it difficult to achieve consistent logging.  This adds an optional second argument to the `setup` function which will replace the default paperplane logger.