### PR TITLE
Change default severity for handled errors to be error and allow options to be passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ const bugsnagClient = bugsnag({
   releaseStage: process.env.SERVICE_ENV
 })
 
-module.exports = require('paperplane-bugsnag')(bugsnagClient)
+const optionalCustomLogger =
+  err => console.error(`My custom logged error: ${err.message}`)
+
+module.exports = require('paperplane-bugsnag')(bugsnagClient, optionalCustomLogger)
 ```
 
 Then use it as the `cry` option in `paperplane` like this:

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ const setup = (bugsnagClient, logger = paperplane.logger) => {
       }
 
       if (notifiable(err)) {
-        const options = mergeDeepRight({ metaData, severity: 'error' }, opts)
+        const options = mergeDeepRight({ metaData }, opts)
         bugsnagClient.notify(err, options)
       }
     }

--- a/test.js
+++ b/test.js
@@ -179,7 +179,7 @@ describe('paperplane-bugsnag + bugsnag.notify', () => {
     })
   })
 
-  describe.only('when provided custom options', () => {
+  describe('when provided custom options', () => {
     const err = Boom.badImplementation()
     const options = {
       severity: 'info',

--- a/test.js
+++ b/test.js
@@ -172,8 +172,7 @@ describe('paperplane-bugsnag + bugsnag.notify', () => {
               query: { id: 'guy' },
               url: 'https://paperplane-bugsnag.zone/api/users?id=guy'
             }
-          },
-          severity: 'error'
+          }
         }
       ])
     })

--- a/test.js
+++ b/test.js
@@ -172,7 +172,30 @@ describe('paperplane-bugsnag + bugsnag.notify', () => {
               query: { id: 'guy' },
               url: 'https://paperplane-bugsnag.zone/api/users?id=guy'
             }
-          }
+          },
+          severity: 'error'
+        }
+      ])
+    })
+  })
+
+  describe.only('when provided custom options', () => {
+    const err = Boom.badImplementation()
+    const options = {
+      severity: 'info',
+    }
+
+    beforeEach(() =>
+      bugsnag.notify(err, options)
+    )
+
+    it('uses them', () => {
+      expect(mockNotify.calls.length).to.equal(1)
+      expect(mockNotify.calls[0]).to.deep.eql([
+        err,
+        {
+          metaData: {},
+          severity: 'info'
         }
       ])
     })


### PR DESCRIPTION
Fix `notify` to actually support the passing of options, also bugsnag sets the default severity for handled errors to `warning`, really a handled error is still an error. `{ severity: 'warning' }` should be passed in if something really is just a warning.