### PR TITLE
Cry if error has `cry` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  Filters `Boom` client errors (4xx) and `Joi` validation errors, and adds request data to the error notification for debugging.
+  Filters `Boom` client errors (4xx) and `Joi` validation errors by default, and adds request data to the error notification for debugging.
 </p>
 
 ## Usage
@@ -45,4 +45,25 @@ const app = require('./rest')
 const cry = require('./lib/bugsnag').notify
 
 http.createServer(mount({ app, cry })).listen(3000, cry)
+```
+
+By default, `Boom` client errors (4xx) and `Joi` validitation errors will be ignored.
+
+```js
+// server/rest.js
+module.exports = req => {
+  const err = Boom.badRequest()
+  return Promise.reject(err) // does not send notification
+}
+```
+
+We can force a notification by setting `cry=true` on the error.
+
+```js
+// server/rest.js
+module.exports = req => {
+  const err = Boom.badRequest()
+  err.cry = true
+  return Promise.reject(err) // sends notification
+}
 ```

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const paperplane = require('paperplane')
 
 const {
-  always, anyPass, complement, evolve, gt,
+  always, anyPass, complement, either, evolve, gt,
   is, mergeDeepRight, pathSatisfies, prop,
 } = require('ramda')
 
@@ -20,7 +20,10 @@ const isJoi =
   prop('isJoi')
 
 const notifiable =
-  complement(anyPass([ clientError, isJoi ]))
+  either(
+    prop('cry'),
+    complement(anyPass([ clientError, isJoi ]))
+  )
 
 const redacted =
   always('REDACTED')

--- a/test.js
+++ b/test.js
@@ -108,7 +108,7 @@ describe('paperplane-bugsnag + bugsnag.notify', () => {
       expect(mockLogger.calls[0]).to.eql([ err ])
     })
 
-    it('does not notify', () =>
+    it('notifies', () =>
       expect(mockNotify.calls.length).to.equal(1)
     )
   })
@@ -162,7 +162,7 @@ describe('paperplane-bugsnag + bugsnag.notify', () => {
       expect(mockLogger.calls[0]).to.eql([ err ])
     })
 
-    it('does not notify', () =>
+    it('notifies', () =>
       expect(mockNotify.calls.length).to.equal(1)
     )
   })

--- a/test.js
+++ b/test.js
@@ -96,6 +96,23 @@ describe('paperplane-bugsnag + bugsnag.notify', () => {
     )
   })
 
+  describe('when Booms with client error (4xx) with cry', () => {
+    const err = Object.assign(Boom.notFound(), { cry: true })
+
+    beforeEach(() =>
+      bugsnag.notify(err)
+    )
+
+    it('logs', () => {
+      expect(mockLogger.calls.length).to.equal(1)
+      expect(mockLogger.calls[0]).to.eql([ err ])
+    })
+
+    it('does not notify', () =>
+      expect(mockNotify.calls.length).to.equal(1)
+    )
+  })
+
   describe('when Booms with server error (5xx)', () => {
     const err = Boom.badImplementation()
 
@@ -128,6 +145,25 @@ describe('paperplane-bugsnag + bugsnag.notify', () => {
 
     it('does not notify', () =>
       expect(mockNotify.calls.length).to.equal(0)
+    )
+  })
+
+  describe('when Joi error with cry', () => {
+    const err = new Error('joi boi')
+    err.cry = true
+    err.isJoi = true
+
+    beforeEach(() =>
+      bugsnag.notify(err)
+    )
+
+    it('logs', () => {
+      expect(mockLogger.calls.length).to.equal(1)
+      expect(mockLogger.calls[0]).to.eql([ err ])
+    })
+
+    it('does not notify', () =>
+      expect(mockNotify.calls.length).to.equal(1)
     )
   })
 


### PR DESCRIPTION
Always report an error to bugsnag if it has a `cry=true` property.